### PR TITLE
[sdc] SDC Chart Update version 0.0.4

### DIFF
--- a/charts/sdc/Chart.yaml
+++ b/charts/sdc/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.2.4"
+appVersion: "0.2.5"
 
 maintainers:
   - name: pgodey
@@ -44,5 +44,5 @@ dependencies:
   - name: inlets-uplink-provider
     alias: inlets
     repository: oci://ghcr.io/openfaasltd
-    version: 0.2.9
+    version: 0.3.0
     condition: inlets.enabled

--- a/charts/sdc/values-sample.yaml
+++ b/charts/sdc/values-sample.yaml
@@ -32,6 +32,7 @@ inlets:
     # Customer tunnels will connect with a URI of:
     # wss://uplink.example.com/namespace/tunnel
     domain: uplink.example.com/namespace/tunnel
+  inletsVersion: 0.9.21
 
 tunnel:
   tunnelname: r1tunnel
@@ -45,7 +46,7 @@ tunnel:
     - 8080
     - 8081
   portRange:
-    - "5001-5010"
+    - "5001-5100"
 
 # Postgresql should be deployed prior to deployment or should be enabled from below
 postgresql:

--- a/charts/sdc/values.yaml
+++ b/charts/sdc/values.yaml
@@ -105,7 +105,7 @@ agents:
   clientSecret: "xxxxx"
   # PortForward__Range should match the start and end ports provided under tunnel
   # PortForward__Range can be a single port if only one port is opened
-  portForward__range: "5001-5009, 8080, 8081"
+  portForward__range: "5001-5100"
   endpoint: https://sdc-envname.radiantlogic.io  # domain for sdc
 
 
@@ -124,7 +124,7 @@ tunnel:
     - 8080
     - 8081
   portRange:
-    - "5001-5010"
+    - "5001-5100"
 
 inlets:
   nodeSelector: {}
@@ -169,7 +169,7 @@ inlets:
 
   # inlets Pro release version for tunnel server Pods
   # Check https://ghcr.io/inlets/inlets-pro for tags
-  inletsVersion: 0.9.18
+  inletsVersion: 0.9.21
   # monitoring tunnels
   prometheus:
     image: prom/prometheus:v2.40.1


### PR DESCRIPTION
1. Bump up the versions for SDC and Inlets SDC - 0.2.5
Inlets version - 0.9.21 and operator 0.3.0
2. Update the port forward range from 5009 - 5100
3.  Deleted the 8080 and 8081 from port-forward ranges
4. Updated portRange to 5001-5100