### PR TITLE
[sdc] SDC version 1.3.0 release

### DIFF
--- a/charts/sdc/Chart.yaml
+++ b/charts/sdc/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.2
+version: 1.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.2"
+appVersion: "1.3.0"
 
 maintainers:
   - name: pgodey


### PR DESCRIPTION
## SDC Helm Chart v1.3.0

Bump SDC Helm chart to version 1.3.0 to align with the new SDC server release.

### Changes
- `Chart.yaml`: `version` 1.2.2 → 1.3.0
- `Chart.yaml`: `appVersion` 1.2.2 → 1.3.0

### Docker Image
```
docker pull radiantone/sdc-server:1.3.0
```

### Release Notes
- SDC Server v1.3.0 enhancements
- Developer release notes: [SDC Server - v1.3.0](https://developer.radiantlogic.com)
- Compatibility details available in **SDC-Server and SDC-Client Versions Compatibility - v8 Agents** Confluence doc

### Release Process
Once merged to `master`, `chart-releaser-action` will automatically:
1. Package the chart as `sdc-1.3.0.tgz`
2. Create GitHub release `sdc-1.3.0`
3. Update `gh-pages` Helm repo index